### PR TITLE
Undo snackbar locks UIEvent channel causing navigation requests (click items or add) to queue up until snackbar is dismissed after which multiple add/edit navigations occur.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,17 +1,18 @@
 plugins {
     id 'com.android.application'
-    id 'kotlin-android'
-    id 'kotlin-kapt'
+    id 'org.jetbrains.kotlin.android'
+    id 'com.google.devtools.ksp'
     id 'dagger.hilt.android.plugin'
 }
 
 android {
-    compileSdk 31
+    namespace = "com.plcoding.mvvmtodoapp"
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.plcoding.mvvmtodoapp"
         minSdk 26
-        targetSdk 31
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 
@@ -28,19 +29,17 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
-        useIR = true
+        jvmTarget = '17'
     }
     buildFeatures {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion compose_version
-        kotlinCompilerVersion '1.5.21'
+        kotlinCompilerExtensionVersion = "1.5.1"
     }
     packagingOptions {
         resources {
@@ -51,35 +50,35 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.4.0'
-    implementation 'com.google.android.material:material:1.4.0'
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.material:material:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.0'
-    implementation 'androidx.activity:activity-compose:1.4.0'
+    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.9.0'
+    implementation platform("androidx.compose:compose-bom:2023.05.01")
+    implementation "androidx.compose.ui:ui"
+    implementation "androidx.compose.material:material"
+    implementation "androidx.compose.ui:ui-tooling-preview"
+
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.1'
+    implementation 'androidx.activity:activity-compose:1.7.2'
     testImplementation 'junit:junit:4.+'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    debugImplementation platform("androidx.compose:compose-bom:2023.05.01")
+    debugImplementation "androidx.compose.ui:ui-tooling"
 
     // Compose dependencies
-    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.4.0"
-    implementation "androidx.navigation:navigation-compose:2.4.0-rc01"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.6.1"
+    implementation "androidx.navigation:navigation-compose:2.7.0"
 
     //Dagger - Hilt
-    implementation "com.google.dagger:hilt-android:2.38.1"
-    kapt "com.google.dagger:hilt-android-compiler:2.37"
-    implementation "androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha03"
-    kapt "androidx.hilt:hilt-compiler:1.0.0"
-    implementation 'androidx.hilt:hilt-navigation-compose:1.0.0-beta01'
+    implementation "com.google.dagger:hilt-android:2.47"
+    ksp "com.google.dagger:hilt-compiler:2.47"
+    implementation 'androidx.hilt:hilt-navigation-compose:1.0.0'
 
     // Room
-    implementation "androidx.room:room-runtime:2.3.0"
-    kapt "androidx.room:room-compiler:2.3.0"
+    implementation "androidx.room:room-runtime:2.5.2"
+    ksp "androidx.room:room-compiler:2.5.2"
 
     // Kotlin Extensions and Coroutines support for Room
-    implementation "androidx.room:room-ktx:2.3.0"
+    implementation "androidx.room:room-ktx:2.5.2"
 }

--- a/app/src/main/java/com/plcoding/mvvmtodoapp/ui/add_edit_todo/AddEditTodoScreen.kt
+++ b/app/src/main/java/com/plcoding/mvvmtodoapp/ui/add_edit_todo/AddEditTodoScreen.kt
@@ -47,9 +47,9 @@ fun AddEditTodoScreen(
                 )
             }
         }
-    ) {
+    ) { paddingValues ->
         Column(
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier.fillMaxSize().padding(paddingValues)
         ) {
             TextField(
                 value = viewModel.title,

--- a/app/src/main/java/com/plcoding/mvvmtodoapp/ui/todo_list/TodoListScreen.kt
+++ b/app/src/main/java/com/plcoding/mvvmtodoapp/ui/todo_list/TodoListScreen.kt
@@ -12,11 +12,13 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.plcoding.mvvmtodoapp.util.UiEvent
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 
 @Composable
 fun TodoListScreen(
@@ -25,18 +27,24 @@ fun TodoListScreen(
 ) {
     val todos = viewModel.todos.collectAsState(initial = emptyList())
     val scaffoldState = rememberScaffoldState()
+    val scope = rememberCoroutineScope()
+
     LaunchedEffect(key1 = true) {
         viewModel.uiEvent.collect { event ->
-            when(event) {
+            when (event) {
+
                 is UiEvent.ShowSnackbar -> {
-                    val result = scaffoldState.snackbarHostState.showSnackbar(
-                        message = event.message,
-                        actionLabel = event.action
-                    )
-                    if(result == SnackbarResult.ActionPerformed) {
-                        viewModel.onEvent(TodoListEvent.OnUndoDeleteClick)
+                    scope.launch {
+                        val result = scaffoldState.snackbarHostState.showSnackbar(
+                            message = event.message,
+                            actionLabel = event.action
+                        )
+                        if (result == SnackbarResult.ActionPerformed) {
+                            viewModel.onEvent(TodoListEvent.OnUndoDeleteClick)
+                        }
                     }
                 }
+
                 is UiEvent.Navigate -> onNavigate(event)
                 else -> Unit
             }
@@ -54,9 +62,9 @@ fun TodoListScreen(
                 )
             }
         }
-    ) {
+    ) { paddingValues ->
         LazyColumn(
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier.fillMaxSize().padding(paddingValues)
         ) {
             items(todos.value) { todo ->
                 TodoItem(

--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    ext {
-        compose_version = '1.0.5'
-    }
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath "com.android.tools.build:gradle:7.0.4"
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31"
-        classpath "com.google.dagger:hilt-android-gradle-plugin:2.38.1"
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
-    }
+plugins {
+    id 'com.android.application' version '8.1.0' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.0' apply false
+    id 'com.google.devtools.ksp' version '1.9.0-1.0.13' apply false
+    id 'com.google.dagger.hilt.android' version '2.47' apply false
 }
 
 task clean(type: Delete) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,5 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+# This Android Gradle plugin (8.1.0) was tested up to compileSdk = 33 (and compileSdkPreview = "UpsideDownCakePrivacySandbox").
+android.suppressUnsupportedCompileSdk=34

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Dec 19 09:53:40 CET 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,10 +1,18 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
         mavenCentral()
-        jcenter() // Warning: this repository is going to shut down soon
     }
 }
+
 rootProject.name = "MVVMTodoApp"
 include ':app'


### PR DESCRIPTION
Fixed issue where deleting an item shows snackbar and then clicking the add button multiple times without dismissing snackbar will queue up numerous navigation requests to add/edit screen. When snackbar undo is pressed, the app navigates immediately to add/edit screen and then the user has to navigate back many times to pop all of the queued-up add/edit navigation screen instances in order to return to the list screen.

The solution is to simply run the snackbar in a scope.launch { ... } block.

Also added the required use of paddingValues lambda parameter for both scaffold calls. The upgraded Compose version needs the received paddingValues to be forwarded to the top Composable Modifier.padding() attribute.

I also upgraded to AGP 8.1.0 Kotlin 1.9.0 Compose Bom 2023.05.01 Gradle 8.1 and compile/target API 34 Creasor 12 minutes ago. The app now runs on Giraffe and Hedgehog.